### PR TITLE
feat: add support for propcache v1.0.0+

### DIFF
--- a/src/cached_ipaddress/_compat.py
+++ b/src/cached_ipaddress/_compat.py
@@ -1,0 +1,8 @@
+"""Compat for external lib versions."""
+
+try:
+    from propcache.api import cached_property
+except ImportError:
+    from propcache import cached_property
+
+__all__ = ("cached_property",)

--- a/src/cached_ipaddress/ipaddress.py
+++ b/src/cached_ipaddress/ipaddress.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from ipaddress import AddressValueError, IPv4Address, IPv6Address, NetmaskValueError
 from typing import Any, Optional, Union
 
-from propcache import cached_property
+from ._compat import cached_property
 
 if sys.version_info < (3, 9):
     cache = lru_cache(maxsize=None)


### PR DESCRIPTION
v1.0.0 moved the public api to propcache.api

see https://github.com/aio-libs/propcache/pull/21
see https://github.com/aio-libs/propcache/issues/18 
see https://github.com/aio-libs/propcache/pull/19