### PR TITLE
ci: checkout fork head repo for pull_request workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref || github.ref_name }}
 
       # Do a dry run of PSR


### PR DESCRIPTION
## What

Pass `repository:` to `actions/checkout` in the release workflow so PRs from forks check out the fork's head commit instead of the base repo at `head_ref`, which does not exist there.

## Why

The PSR dry run job currently fails on fork PRs because `ref: ${{ github.head_ref }}` resolves against `github.repository`, where that ref is not present; the new expression falls back to `github.repository` for push events, so non-PR runs are unaffected.

## Testing

Workflow only change, will be exercised by this PR itself.